### PR TITLE
fix: display help if no arguments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use rand::Rng;
 use clap::Parser;
 
 #[derive(Parser)]
-#[command(version, about)]
+#[command(version, about, arg_required_else_help(true))]
 struct Cli {
     count: i32,
 }


### PR DESCRIPTION
Saw your comment (https://github.com/Noxyntious/meower/pull/7#pullrequestreview-2080486832) and it was an easy fix.