### PR TITLE
chore: bump Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "meower"
-version = "0.1.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "rand",


### PR DESCRIPTION
You forgot to include the lockfile update in https://github.com/Noxyntious/meower/commit/e3428d20d784b9388856b6b9331ba00804d4d867.